### PR TITLE
Add option to disable pinned tab re-ordering

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "MRU Sliding Tabs",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Slides active tab to the left in MRU order",
   "action": {
     "default_title": "Click for options",
@@ -14,7 +14,8 @@
   "options_page": "src/options.html",
   "permissions": ["storage", "tabGroups"],
   "background": {
-    "service_worker": "src/background.js"
+    "service_worker": "src/background.js",
+    "type": "module"
   },
   "options_ui": {
     "page": "src/options.html",

--- a/src/options.html
+++ b/src/options.html
@@ -3,29 +3,46 @@
     <title>MRU Sliding Tabs Option</title>
     <style>
       body {
-        min-width: 200px;
+        min-width: 400px;
         background-color: #29292e;
         color: white;
         border: 1px solid #000;
         margin: 0px;
         padding: 10px;
       }
-      form {
-        text-align: center;
+      div,
+      label {
+        display: flex;
+        align-items: center;
+        margin-bottom: 10px;
+      }
+      div > img,
+      div > input,
+      span {
+        margin-right: 10px;
       }
     </style>
   </head>
 
   <body>
     <form id="option_form">
-      <img src="resources/icon_48.png" width="16" height="16" />
-      <strong>MRU Sliding Tabs Option</strong>
-      <p>Delay before moving tabs:</p>
-      <p>
+      <div class="box">
+        <img src="resources/icon_48.png" width="16" height="16" />
+        <strong>MRU Sliding Tabs Option</strong>
+      </div>
+      <div>
+        <span>Delay before moving tabs:</span>
         <input id="delay" type="text" size="6" /> seconds
-        <input type="submit" />
-      </p>
+      </div>
+      <div>
+        <label>
+          <input id="order_pinned" type="checkbox" /> Re-order pinned tabs
+        </label>
+      </div>
+      <div>
+        <input type="submit" value="Save" />
+      </div>
     </form>
   </body>
-  <script src="options.js"></script>
+  <script defer src="options.js" type="module"></script>
 </html>

--- a/src/options.js
+++ b/src/options.js
@@ -18,21 +18,26 @@
 // BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 // TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
+const options = {};
 
 document.getElementById("option_form").addEventListener("submit", function () {
   const delay = parseFloat(document.getElementById("delay").value);
   if (isNaN(delay) || delay < 0) {
     delay = 1;
   }
+  options.delay = delay;
 
-  chrome.storage.local.set({ delay: delay });
+  const reOrderPinnedTabs = document.getElementById("order_pinned").checked;
+  options.reOrderPinnedTabs = reOrderPinnedTabs;
+
+  chrome.storage.local.set({ options });
   window.close();
 });
 
 // Restores select box state to saved value from localStorage.
-window.onload = function () {
-  chrome.storage.local.get("delay").then((s) => {
-    const delay = s.delay || 1;
-    document.getElementById("delay").value = delay;
-  });
-};
+const data = await chrome.storage.local.get("options");
+Object.assign(options, data.options);
+const delay = options.delay || 1;
+document.getElementById("delay").value = delay;
+document.getElementById("order_pinned").checked =
+  options.reOrderPinnedTabs ?? true;


### PR DESCRIPTION
Added option to disable pinned tab re-ordering. 
Re-ordering is enabled by default to keep previous behavior